### PR TITLE
Update ArtistIndex.js

### DIFF
--- a/src/components/artists/ArtistIndex.js
+++ b/src/components/artists/ArtistIndex.js
@@ -37,7 +37,7 @@ class ArtistIndex extends Component {
           <p>
             <b>{artist.age}</b> years old
             <br />
-            {artist.albums ? artist.albums.length : 0} albums released
+            {artist.yearsActive} years active
           </p>
         </div>
         <Link to={`artists/${artist._id}`} className="secondary-content">


### PR DESCRIPTION
According to the videos in section 11, 'years active' should be displayed with the artist results, not 'albums released.' This change helps make the starter code line up with the video presentations in section 11.